### PR TITLE
frameworks/base: Support for third party NFC features and extensions

### DIFF
--- a/core/java/android/nfc/INfcAdapter.aidl
+++ b/core/java/android/nfc/INfcAdapter.aidl
@@ -1,4 +1,7 @@
 /*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ * Not a Contribution.
+ *
  * Copyright (C) 2010 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +34,7 @@ import android.nfc.INfcUnlockHandler;
 import android.nfc.ITagRemovedCallback;
 import android.nfc.INfcDta;
 import android.os.Bundle;
+import android.os.IBinder;
 
 /**
  * @hide
@@ -42,6 +46,8 @@ interface INfcAdapter
     INfcFCardEmulation getNfcFCardEmulationInterface();
     INfcAdapterExtras getNfcAdapterExtrasInterface(in String pkg);
     INfcDta getNfcDtaInterface(in String pkg);
+    IBinder getNfcAdapterVendorInterface(in String vendor);
+
     int getState();
     boolean disable(boolean saveState);
     boolean enable();

--- a/core/java/android/nfc/cardemulation/AidGroup.java
+++ b/core/java/android/nfc/cardemulation/AidGroup.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ * Not a Contribution.
+ *
  * Copyright (C) 2015 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +40,7 @@ import android.util.Log;
  *
  * @hide
  */
-public final class AidGroup implements Parcelable {
+public class AidGroup implements Parcelable {
     /**
      * The maximum number of AIDs that can be present in any one group.
      */
@@ -45,9 +48,9 @@ public final class AidGroup implements Parcelable {
 
     static final String TAG = "AidGroup";
 
-    final List<String> aids;
-    final String category;
-    final String description;
+    protected List<String> aids;
+    protected String category;
+    protected String description;
 
     /**
      * Creates a new AidGroup object.

--- a/core/java/android/nfc/cardemulation/ApduServiceInfo.java
+++ b/core/java/android/nfc/cardemulation/ApduServiceInfo.java
@@ -1,4 +1,7 @@
 /*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ * Not a Contribution.
+ *
  * Copyright (C) 2013 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,53 +51,53 @@ import java.util.Map;
 /**
  * @hide
  */
-public final class ApduServiceInfo implements Parcelable {
+public class ApduServiceInfo implements Parcelable {
     static final String TAG = "ApduServiceInfo";
 
     /**
      * The service that implements this
      */
-    final ResolveInfo mService;
+    protected ResolveInfo mService;
 
     /**
      * Description of the service
      */
-    final String mDescription;
+    protected String mDescription;
 
     /**
      * Whether this service represents AIDs running on the host CPU
      */
-    final boolean mOnHost;
+    protected boolean mOnHost;
 
     /**
      * Mapping from category to static AID group
      */
-    final HashMap<String, AidGroup> mStaticAidGroups;
+    protected HashMap<String, AidGroup> mStaticAidGroups;
 
     /**
      * Mapping from category to dynamic AID group
      */
-    final HashMap<String, AidGroup> mDynamicAidGroups;
+    protected HashMap<String, AidGroup> mDynamicAidGroups;
 
     /**
      * Whether this service should only be started when the device is unlocked.
      */
-    final boolean mRequiresDeviceUnlock;
+    protected boolean mRequiresDeviceUnlock;
 
     /**
      * The id of the service banner specified in XML.
      */
-    final int mBannerResourceId;
+    protected int mBannerResourceId;
 
     /**
      * The uid of the package the service belongs to
      */
-    final int mUid;
+    protected int mUid;
 
     /**
      * Settings Activity for this service
      */
-    final String mSettingsActivityName;
+    protected String mSettingsActivityName;
 
     /**
      * @hide

--- a/core/java/android/nfc/tech/MifareClassic.java
+++ b/core/java/android/nfc/tech/MifareClassic.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright (C) 2015 NXP Semiconductors
+ * The original Work has been changed by NXP Semiconductors.
  * Copyright (C) 2010 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,6 +174,10 @@ public final class MifareClassic extends BasicTagTechnology {
         case 0x18:
             mType = TYPE_CLASSIC;
             mSize = SIZE_4K;
+            break;
+        case 0x19:
+            mType = TYPE_CLASSIC;
+            mSize = SIZE_2K;
             break;
         case 0x28:
             mType = TYPE_CLASSIC;


### PR DESCRIPTION
This change is a combination of following changes:

1) frameworks/base: Support for third party NFC features

   Integration of below modifications are necessary to support
   third party NFC software:

   * a new interface in INfcAdapter.aidl allowing vendor specific
     extensions and features
   * a new size for MIFARE Classic tags
   * allowing extensions to AidGroup and changing the protection
     of the instance variables to package protected

   Author: Puneet Mishra <puneetm@codeaurora.org>
   Change-Id: Ic11dc68c4ea83262c705ec50b75b5808aa064f82
   (integrated from commit 57a001b7851c97d41f042dda643f9a87aa6306e5)

2) NFC: Allow extensions to ApduServiceInfo

   Mobile network operators expect additional
   features in ApduServiceInfo to support their
   payment solutions. To achieve this, the final
   keyword is removed from the class definition
   and its instance variables, thereby allowing
   extensions to the class.

   Author: Puneet Mishra <puneetm@codeaurora.org>
   Change-Id: I9058d08e729027b04ee94405c66ff9d99c0f963b

Change-Id: I04bbe46bf9efd032e973bba7a16dc430fb6edd12
(cherry picked from commit d6a0afcb2ab0e9514305a2f896aa7f36df557414)